### PR TITLE
Fix references to Docker repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ It started out as https://github.com/znly/docker-protobuf fork, but grew into a 
 
 ## Usage
 ```
-$ docker run --rm -v<some-path>:<some-path> -w<some-path> TheThingsIndustries/protoc [OPTION] PROTO_FILES
+$ docker run --rm -v<some-path>:<some-path> -w<some-path> thethingsindustries/protoc [OPTION] PROTO_FILES
 ```
 
 For help try:
 ```
-$ docker run --rm TheThingsIndustries/protoc --help
+$ docker run --rm thethingsindustries/protoc --help
 ```


### PR DESCRIPTION
The docker repo names in the README do not match the the actual repo (https://hub.docker.com/r/thethingsindustries/protoc), which causes errors in the docker CLI:

```
$ docker run --rm Thethingsindustries/protoc --help
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
``` 

To resolve this, this PR lowercases both references to the repository. 