### PR TITLE
Resolving shared libraries not found errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,4 +225,5 @@ RUN apk add --no-cache bash libstdc++ && \
     ln -s /usr/bin/grpc_ruby_plugin /usr/bin/protoc-gen-grpc-ruby && \
     ln -s /usr/bin/protoc-gen-swiftgrpc /usr/bin/protoc-gen-grpc-swift
 COPY protoc-wrapper /usr/bin/protoc-wrapper
+ENV LD_LIBRARY_PATH='/usr/lib:/usr/lib64:/usr/lib/local'
 ENTRYPOINT ["protoc-wrapper", "-I/usr/include"]


### PR DESCRIPTION
#### Summary

Addresses issue #52 

#### Changes

- Simply adds an `LD_LIBRARY_PATH` ENV value to the `Dockerfile` such that, when called, the `protoc-gen-grpc-*` binaries will properly run and not error out.
