### PR TITLE
Add typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It started out as https://github.com/znly/docker-protobuf fork, but grew into a 
 - https://github.com/stepancheg/rust-protobuf
 - https://github.com/TheThingsIndustries/protoc-gen-fieldmask
 - https://github.com/TheThingsIndustries/protoc-gen-gogottn
+- https://github.com/improbable-eng/ts-protoc-gen
 
 ## Supported languages
 - C
@@ -38,6 +39,7 @@ It started out as https://github.com/znly/docker-protobuf fork, but grew into a 
 - Ruby
 - Rust
 - Swift
+- Typescript
 
 ## Usage
 ```

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,6 @@ docker build \
 --build-arg RUST_VERSION="${RUST_VERSION:-"1.47.0"}" \
 --build-arg SWIFT_VERSION="${SWIFT_VERSION:-"5.1.5"}" \
 --build-arg UPX_VERSION="${UPX_VERSION:-"3.96"}" \
+--build-arg NODE_VERSION="${NODE_VERSION:-"14.15.0"}" \
+--build-arg TS_PROTOC_GEN_VERSION="${TS_PROTOC_GEN_VERSION:-"0.13.0"}" \
 ${@} .


### PR DESCRIPTION
Hi there, thanks for this great image

#### Summary
This PR resolves #9 adding typescript support through  [ts-protoc-gen](https://github.com/improbable-eng/ts-protoc-gen)

#### Changes
- **runtime image is now node-alpine based (`node:${NODE_VERSION}-alpine${ALPINE_VERSION}`) rather than `alpine${ALPINE_VERSION}`**
- add `ts-protoc-gen` npm global package
- add `ts-protoc-gen` to protoc plugins

#### Notes for Reviewers
I'm aware that changing the final image is not the best but I've chosen to do that because in unfortunately `ts-protoc-gen` is a node script instead of a runnable binary, therefore node must be installed.
I've tried to install node through `apk` but the available versions are very limited (the latest version available is nodejs-12.18.4).
I've tried the installation directly with the binary through `wget` but it didn't work because of a broblem with `musl` library.
That being said, in my opinion the best option in order to have a stable image is to use the official, alpine-based, node image.
If you think there's a better solution, I'm very open to suggestions and ideas

#### Release Notes
Despite the final image is changed, this pull request should not contains any breaking change, however I've been able to test only the ts, js and go generation because my current stack contains only this three languages 