### PR TITLE
build.sh: update dart deps versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 docker build \
 --build-arg ALPINE_VERSION="${ALPINE_VERSION:-"3.12"}" \
---build-arg DART_PROTOBUF_VERSION="${DART_PROTOBUF_VERSION:-"1.0.1"}" \
---build-arg DART_VERSION="${DART_VERSION:-"2.7.2"}" \
+--build-arg DART_PROTOBUF_VERSION="${DART_PROTOBUF_VERSION:-"1.1.0"}" \
+--build-arg DART_VERSION="${DART_VERSION:-"2.10.4"}" \
 --build-arg GO_VERSION="${GO_VERSION:-"1.15.3"}" \
 --build-arg GRPC_GATEWAY_VERSION="${GRPC_GATEWAY_VERSION:-"1.16.0"}" \
 --build-arg GRPC_JAVA_VERSION="${GRPC_JAVA_VERSION:-"1.33.0"}" \


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Update the versions of Dart runtime and the Dart protobuf package. The older version of the protoc Dart plugin generates code that uses deprecated methods. The linter warning is:

```
'$createCall' is deprecated and shouldn't be used. This method does not invoke interceptors and is superseded
by $createStreamingCall and $createUnaryCall which invoke interceptors.

If you are getting this warning in autogenerated protobuf client stubs,
regenerate these stubs using  protobuf compiler plugin version 19.2.0 or newer.
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Update the version set to `DART_PROTOBUF_VERSION`
- Update the version set to `DART_VERSION`