### PR TITLE
Update gRPC-gateway to v2.1.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ docker build \
 --build-arg DART_PROTOBUF_VERSION="${DART_PROTOBUF_VERSION:-"1.1.0"}" \
 --build-arg DART_VERSION="${DART_VERSION:-"2.10.4"}" \
 --build-arg GO_VERSION="${GO_VERSION:-"1.15.6"}" \
---build-arg GRPC_GATEWAY_VERSION="${GRPC_GATEWAY_VERSION:-"2.0.1"}" \
+--build-arg GRPC_GATEWAY_VERSION="${GRPC_GATEWAY_VERSION:-"2.1.0"}" \
 --build-arg GRPC_JAVA_VERSION="${GRPC_JAVA_VERSION:-"1.34.1"}" \
 --build-arg GRPC_RUST_VERSION="${GRPC_RUST_VERSION:-"0.8.2"}" \
 --build-arg GRPC_SWIFT_VERSION="${GRPC_SWIFT_VERSION:-"0.9.2"}" \


### PR DESCRIPTION
[Changelog](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v2.1.0)