### PR TITLE
Use 1.0 version of grpc-swift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,12 +191,12 @@ RUN mkdir -p /grpc-swift && \
     curl -sSL https://api.github.com/repos/grpc/grpc-swift/tarball/${GRPC_SWIFT_VERSION} | tar xz --strip 1 -C /grpc-swift && \
     cd /grpc-swift && make && \
     install -Ds /grpc-swift/protoc-gen-swift /protoc-gen-swift/protoc-gen-swift && \
-    install -Ds /grpc-swift/protoc-gen-swiftgrpc /protoc-gen-swift/protoc-gen-swiftgrpc && \
+    install -Ds /grpc-swift/protoc-gen-grpc-swift /protoc-gen-swift/protoc-gen-grpc-swift && \
     cp /lib64/ld-linux-x86-64.so.2 \
-        $(ldd /protoc-gen-swift/protoc-gen-swift /protoc-gen-swift/protoc-gen-swiftgrpc | awk '{print $3}' | grep /lib | sort | uniq) \
+        $(ldd /protoc-gen-swift/protoc-gen-swift /protoc-gen-swift/protoc-gen-grpc-swift | awk '{print $3}' | grep /lib | sort | uniq) \
         /protoc-gen-swift/ && \
     find /protoc-gen-swift/ -name 'lib*.so*' -exec patchelf --set-rpath /protoc-gen-swift {} \; && \
-    for p in protoc-gen-swift protoc-gen-swiftgrpc; do \
+    for p in protoc-gen-swift protoc-gen-grpc-swift; do \
         patchelf --set-interpreter /protoc-gen-swift/ld-linux-x86-64.so.2 /protoc-gen-swift/${p}; \
     done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ RUN apt-get update && \
 ARG GRPC_SWIFT_VERSION
 RUN mkdir -p /grpc-swift && \
     curl -sSL https://api.github.com/repos/grpc/grpc-swift/tarball/${GRPC_SWIFT_VERSION} | tar xz --strip 1 -C /grpc-swift && \
-    cd /grpc-swift && make && \
+    cd /grpc-swift && make && make plugins && \
     install -Ds /grpc-swift/protoc-gen-swift /protoc-gen-swift/protoc-gen-swift && \
     install -Ds /grpc-swift/protoc-gen-grpc-swift /protoc-gen-swift/protoc-gen-grpc-swift && \
     cp /lib64/ld-linux-x86-64.so.2 \

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ docker build \
 --build-arg GRPC_GATEWAY_VERSION="${GRPC_GATEWAY_VERSION:-"2.3.0"}" \
 --build-arg GRPC_JAVA_VERSION="${GRPC_JAVA_VERSION:-"1.36.0"}" \
 --build-arg GRPC_RUST_VERSION="${GRPC_RUST_VERSION:-"0.8.2"}" \
---build-arg GRPC_SWIFT_VERSION="${GRPC_SWIFT_VERSION:-"0.9.2"}" \
+--build-arg GRPC_SWIFT_VERSION="${GRPC_SWIFT_VERSION:-"1.0.0"}" \
 --build-arg GRPC_VERSION="${GRPC_VERSION:-"1.36.4"}" \
 --build-arg GRPC_WEB_VERSION="${GRPC_WEB_VERSION:-"1.2.1"}" \
 --build-arg NODE_VERSION="${NODE_VERSION:-"14.15.4"}" \
@@ -25,7 +25,7 @@ docker build \
 --build-arg PROTOC_GEN_VALIDATE_VERSION="${PROTOC_GEN_VALIDATE_VERSION:-"0.5.0"}" \
 --build-arg RUST_PROTOBUF_VERSION="${RUST_PROTOBUF_VERSION:-"2.22.1"}" \
 --build-arg RUST_VERSION="${RUST_VERSION:-"1.50.0"}" \
---build-arg SWIFT_VERSION="${SWIFT_VERSION:-"5.1.5"}" \
+--build-arg SWIFT_VERSION="${SWIFT_VERSION:-"5.2.5"}" \
 --build-arg TS_PROTOC_GEN_VERSION="${TS_PROTOC_GEN_VERSION:-"0.14.0"}" \
 --build-arg UPX_VERSION="${UPX_VERSION:-"3.96"}" \
 ${@} .


### PR DESCRIPTION
Summary

Hi! Thank you for your amazing open-source work!
Recently 1.0 version of [grpc-swift](https://github.com/grpc/grpc-swift) was released.
I think many people would like to use officially released version of grpc-swift!

Changes

* Update `GRPC_SWIFT_VERSION` in build.sh
* Because grpc-swift 1.0 depends on swift5.2, also updated `SWIFT_VERSION`