### PR TITLE
Add gotemplate plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,6 @@ RUN mkdir -p /dart-protobuf && \
     install -D /dart-protobuf/protoc_plugin/protoc_plugin /out/usr/bin/protoc-gen-dart
 
 FROM moul/protoc-gen-gotemplate:v${GOTEMPLATE_VERSION} as protoc_gotemplate
-RUN ls -la /go/bin/protoc-gen-gotemplate
 
 FROM alpine:${ALPINE_VERSION} as packer
 RUN apk add --no-cache curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,7 @@ RUN mkdir -p ${GOPATH}/src/github.com/chrusty/protoc-gen-jsonschema && \
     install -Ds /protoc-gen-jsonschema/protoc-gen-jsonschema /out/usr/bin/protoc-gen-jsonschema && \
     install -D ./options.proto /out/usr/include/github.com/chrusty/protoc-gen-jsonschema/options.proto
 
+
 FROM rust:${RUST_VERSION}-alpine as rust_builder
 RUN apk add --no-cache curl
 RUN rustup target add x86_64-unknown-linux-musl

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,6 @@ RUN upx --lzma $(find /out/usr/bin/ \
 RUN find /out -name "*.a" -delete -or -name "*.la" -delete
 
 
-
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
 
 ARG TS_PROTOC_GEN_VERSION

--- a/build.sh
+++ b/build.sh
@@ -27,4 +27,5 @@ docker build \
 --build-arg TS_PROTOC_GEN_VERSION="${TS_PROTOC_GEN_VERSION:-"0.14.0"}" \
 --build-arg UPX_VERSION="${UPX_VERSION:-"3.96"}" \
 --build-arg JSONSCHEMA_VERSION="${JSONSCHEMA_VERSION:-"1.3.1"}" \
+--build-arg GOTEMPLATE_VERSION="${GOTEMPLATE_VERSION:-"1.11.2"}" \
 ${@} .


### PR DESCRIPTION
#### Summary

The goal is to add the protoc plugin [gotemplate](https://github.com/moul/protoc-gen-gotemplate)  
This plugin is available in the zenly image.  

#### Changes

- Copy the binary from the image of `protoc-gen-gotemplate` in the bundle image