### PR TITLE
ci: update deps

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,24 +15,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1  
+      uses: docker/setup-buildx-action@v2
       with:
         install: true
 
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         image: tonistiigi/binfmt:latest
 
     - name: Docker meta
       id: docker_meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: rvolosatovs/protoc
         tags: |
@@ -46,7 +46,7 @@ jobs:
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -55,7 +55,7 @@ jobs:
       run: cat deps.list >> $GITHUB_ENV
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
This PR updates CI to work on the current build of the Github Runner without warnings relating to Node 8 deprecation.

@rvolosatovs can you please verify that the secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` are set in this repo for the `rvolosatovs` Docker Hub account? I would like to test the CI and ensure I can trigger a successful build and push an image to the repo by creating a tag.