### PR TITLE
feat: xx-cargo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     --mount=type=cache,target=/root/.cargo/registry/index \
     cargo fetch
 ARG TARGETPLATFORM
-RUN xx-cargo build --release
+RUN xx-cargo --config profile.release.strip=true build --release
 RUN install -D /rust-protobuf/target/$(xx-cargo --print-target)/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
 RUN xx-verify /out/usr/bin/protoc-gen-rust
 
@@ -216,7 +216,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     --mount=type=cache,target=/root/.cargo/registry/index \
     cargo fetch
 ARG TARGETPLATFORM
-RUN xx-cargo build --release
+RUN xx-cargo --config profile.release.strip=true build --release
 RUN install -D /grpc-rust/target/$(xx-cargo --print-target)/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc
 RUN xx-verify /out/usr/bin/protoc-gen-rust-grpc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -198,8 +198,7 @@ RUN curl -sSL https://api.github.com/repos/stepancheg/rust-protobuf/tarball/v${P
 WORKDIR /rust-protobuf/protobuf-codegen
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
-RUN ls -lha /rust-protobuf/target/release
-RUN install -Ds /rust-protobuf/target/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
+RUN install -Ds /rust-protobuf/target/$(xx-cargo --print-target)/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
 RUN xx-verify /out/usr/bin/protoc-gen-rust
 
 
@@ -210,7 +209,7 @@ RUN curl -sSL https://api.github.com/repos/stepancheg/grpc-rust/tarball/v${GRPC_
 WORKDIR /grpc-rust/grpc-compiler
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
-RUN install -Ds /grpc-rust/target/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc
+RUN install -Ds /grpc-rust/target/$(xx-cargo --print-target)/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc
 RUN xx-verify /out/usr/bin/protoc-gen-rust-grpc
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     cargo fetch
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
-RUN install -Ds /rust-protobuf/target/$(xx-cargo --print-target)/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
+RUN install -D /rust-protobuf/target/$(xx-cargo --print-target)/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
 RUN xx-verify /out/usr/bin/protoc-gen-rust
 
 
@@ -217,7 +217,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     cargo fetch
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
-RUN install -Ds /grpc-rust/target/$(xx-cargo --print-target)/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc
+RUN install -D /grpc-rust/target/$(xx-cargo --print-target)/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc
 RUN xx-verify /out/usr/bin/protoc-gen-rust-grpc
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -196,6 +196,10 @@ RUN mkdir -p /rust-protobuf
 ARG PROTOC_GEN_RUST_VERSION
 RUN curl -sSL https://api.github.com/repos/stepancheg/rust-protobuf/tarball/v${PROTOC_GEN_RUST_VERSION} | tar xz --strip 1 -C /rust-protobuf
 WORKDIR /rust-protobuf/protobuf-codegen
+RUN --mount=type=cache,target=/root/.cargo/git/db \
+    --mount=type=cache,target=/root/.cargo/registry/cache \
+    --mount=type=cache,target=/root/.cargo/registry/index \
+    cargo fetch
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
 RUN install -Ds /rust-protobuf/target/$(xx-cargo --print-target)/release/protoc-gen-rust /out/usr/bin/protoc-gen-rust
@@ -207,6 +211,10 @@ RUN mkdir -p /grpc-rust
 ARG GRPC_RUST_VERSION
 RUN curl -sSL https://api.github.com/repos/stepancheg/grpc-rust/tarball/v${GRPC_RUST_VERSION} | tar xz --strip 1 -C /grpc-rust
 WORKDIR /grpc-rust/grpc-compiler
+RUN --mount=type=cache,target=/root/.cargo/git/db \
+    --mount=type=cache,target=/root/.cargo/registry/cache \
+    --mount=type=cache,target=/root/.cargo/registry/index \
+    cargo fetch
 ARG TARGETPLATFORM
 RUN xx-cargo build --release
 RUN install -Ds /grpc-rust/target/$(xx-cargo --print-target)/release/protoc-gen-rust-grpc /out/usr/bin/protoc-gen-rust-grpc


### PR DESCRIPTION
We are having problems moving forward with PRs on this repo because CI is failing. Investigation showed this was likely occurring due to an OOM error while attempting to compile two Rust targets simultaneously in QEMU. On my local machine, this would consume 32GB RAM + 8GB swap and hard crash the system. I think this was also the cause of CI logs not being available, the runner probably died before anything could be uploaded (even though the stream was visible during a run).

https://github.com/tonistiigi/xx/ recently added support for Rust, and using the Rust cross compiler shows no significant memory consumption. `strip` was moved to be handled by `cargo` as well, to ensure that the native toolchain is used to process cross-compiled binaries. And caching support was added to the Rust section of the Dockerfile to speed up local development and support future caching in CI.