### PR TITLE
doc: remove outdated java on `arm64` notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It started out as https://github.com/znly/docker-protobuf fork, but grew into a 
 - [grpc-ecosystem/grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
 - [grpc/grpc](https://github.com/grpc/grpc)
 - [grpc/grpc-go](https://github.com/grpc/grpc-go)
-- [grpc/grpc-java](https://github.com/grpc/grpc-java) (not on `arm64`)
+- [grpc/grpc-java](https://github.com/grpc/grpc-java)
 - [grpc/grpc-swift](https://github.com/grpc/grpc-swift) (not on `arm64`, see https://github.com/rvolosatovs/docker-protobuf/issues/77 for potential issues)
 - [grpc/grpc-web](https://github.com/grpc/grpc-web)
 - [improbable-eng/ts-protoc-gen](https://github.com/improbable-eng/ts-protoc-gen)


### PR DESCRIPTION
Signed-off-by: Roman Volosatovs <rvolosatovs@riseup.net>