### PR TITLE
ci: renovate googleapis/googleapis

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,13 @@
     },
     {
       "fileMatch": ["^deps\\.list$"],
+      "matchStrings": ["GOOGLE_API_VERSION=(?<currentDigest>.*?)\\n"],
+      "depNameTemplate": "https://github.com/googleapis/googleapis",
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "master"
+    },
+    {
+      "fileMatch": ["^deps\\.list$"],
       "matchStrings": ["GRPC_GATEWAY_VERSION=(?<currentValue>.*?)\\n"],
       "depNameTemplate": "grpc-ecosystem/grpc-gateway",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
This PR provides config for Renovate to update the head digest from `master` ref for the `googleapis/googleapis` dependency. It's a bit different than the other configs, credit to Renovate devs for pointing me in the right direction [here](https://github.com/renovatebot/renovate/discussions/19076#discussioncomment-4374161).

This repo is very noisy, so we should schedule Renovate to run less frequently (1x per week?) to avoid the bot opening 10+ PRs per day here.