### PR TITLE
ci: only renovate node lts versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,9 +54,10 @@
     },
     {
       "fileMatch": ["^deps\\.list$"],
-      "matchStrings": ["NODE_IMAGE_VERSION=(?<currentValue>.*?)\\n"],
+      "matchStrings": ["NODE_IMAGE_VERSION=(?<currentValue>.*?)-alpine3.16\\n"],
       "depNameTemplate": "node",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "node",
+      "versioningTemplate": "node"
     },
     {
       "fileMatch": ["^deps\\.list$"],


### PR DESCRIPTION
This PR configures renovate to extract the full Node version from the Docker tag, and update that with LTS versions only while pinning a static version of Alpine. This is necessary as Renovate devs [figure out](https://github.com/renovatebot/renovate/issues/5990) how to best handle complex docker tags like this.

Since it takes some time for Alpine releases (e.g. the new `alpine:3.17`) to become available in downstream projects based on it (e.g. `node:18.12.1-alpine3.17` does not exist yet), I would suggest we leave Renovate's Alpine PR open when it occurs every ~6 months and manually update any alpine versions we specify in deps (e.g. also `rust:1.65.0-alpine3.16`) as they become available, merging it only when all deps are based on the same updated Alpine version.