### PR TITLE
chore: disable arm build for protoc_gen_js

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
+    - name: Delete tools folder
+      run: rm -rf /opt/hostedtoolcache
+
     - uses: actions/checkout@v3
 
     - name: Set up Docker Buildx

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
+    # Remove pre-populated tools not needed for Docker builds to free up space for cache export
+    # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
     - name: Delete tools folder
       run: rm -rf /opt/hostedtoolcache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -380,7 +380,10 @@ RUN apt-get install -y curl
 RUN mkdir -p /dart-protobuf
 ARG PROTOC_GEN_DART_VERSION
 RUN curl -sSL https://api.github.com/repos/google/protobuf.dart/tarball/protoc_plugin-${PROTOC_GEN_DART_VERSION} | tar xz --strip 1 -C /dart-protobuf
-WORKDIR /dart-protobuf/protoc_plugin 
+WORKDIR /dart-protobuf/protoc_plugin
+# Use Dart mirror to work around connectivity problems to default host when building in QEMU
+# https://stackoverflow.com/questions/70729747
+ARG PUB_HOSTED_URL=https://pub.flutter-io.cn
 RUN dart pub get
 RUN dart compile exe --verbose bin/protoc_plugin.dart -o protoc_plugin
 RUN install -D /dart-protobuf/protoc_plugin/protoc_plugin /out/usr/bin/protoc-gen-dart


### PR DESCRIPTION
Hi @rvolosatovs I have some time to work on this again over the next couple of weeks!

This PR disables ARM builds for protoc_gen_js due to extremely slow builds in the emulator. Both Bazel and protoc_gen_js need to be built, and Bazel cannot be built on ARM currently due to [this bug](https://github.com/bazelbuild/bazel/issues/17220).

Instead, I have created a bazel6 package for x86_64 in Alpine, so Bazel no longer needs to be built by us. I'll create an issue describing the lack of protoc_gen_js support on ARM, and continue working with Alpine to try and release bazel6 as an Alpine package with ARM support.