### PR TITLE
refactor: parallel upx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -414,9 +414,10 @@ COPY --from=protoc_gen_rust /out/ /out/
 COPY --from=protoc_gen_scala /out/ /out/
 COPY --from=protoc_gen_validate /out/ /out/
 ARG TARGETARCH
-RUN upx --lzma $(find /out/usr/bin/ -type f \
-            -name 'protoc-gen-*' -or \
-            -name 'grpc_*')
+RUN find /out/usr/bin/ -type f \
+            -name 'protoc-gen-*' | \
+            xargs -P $(nproc) -I{} \
+            upx --lzma {}
 RUN find /out -name "*.a" -delete -or -name "*.la" -delete
 
 


### PR DESCRIPTION
One of the slowest steps for me during local development is UPX compression, which is single threaded and processes each file in sequence. I need to wait for it in order to run the test stage to see if the previously compiled binaries work.

This PR starts `nproc` UPX processes and runs them in parallel for a considerable speedup on systems with lots of cores.