### PR TITLE
fix: no space left on device

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -20,12 +20,20 @@ jobs:
     - name: Maximize build space
       uses: easimon/maximize-build-space@master
       with:
-        root-reserve-mb: 81920
+        build-mount-path: /home/runner/work/_temp/docker
+        root-reserve-mb: 10240
         remove-dotnet: true
         remove-android: true
         remove-haskell: true
         remove-codeql: true
         remove-docker-images: true
+
+    - name: Move Docker data root to work directory
+      run: |
+        sudo systemctl stop docker
+        sudo mkdir -p /home/runner/work/docker-protobuf/docker-protobuf/docker
+        sudo sh -c 'printf "{\n  \"exec-opts\": [\n    \"native.cgroupdriver=cgroupfs\"\n  ],\n  \"cgroup-parent\": \"/actions_job\",\n  \"data-root\": \"/home/runner/work/_temp/docker\"\n}\n" > /etc/docker/daemon.json'
+        sudo systemctl start docker
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,10 +17,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    # Remove pre-populated tools not needed for Docker builds to free up space for cache export
-    # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
-    - name: Delete tools folder
-      run: rm -rf /opt/hostedtoolcache
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        remove-dotnet: true
+        remove-android: true
+        remove-haskell: true
+        remove-codeql: true
+        remove-docker-images: true
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Move Docker data root to work directory
       run: |
         sudo systemctl stop docker
-        sudo mkdir -p /home/runner/work/docker-protobuf/docker-protobuf/docker
         sudo sh -c 'printf "{\n  \"exec-opts\": [\n    \"native.cgroupdriver=cgroupfs\"\n  ],\n  \"cgroup-parent\": \"/actions_job\",\n  \"data-root\": \"/home/runner/work/_temp/docker\"\n}\n" > /etc/docker/daemon.json'
         sudo systemctl start docker
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Maximize build space
       uses: easimon/maximize-build-space@master
       with:
+        root-reserve-mb: 81920
         remove-dotnet: true
         remove-android: true
         remove-haskell: true


### PR DESCRIPTION
CI was failing with error `build System.IO.IOException: No space left on device : '/home/runner/runners/2.311.0/_diag/Worker_20231116-033846-utc.log'`

This PR uses a more advanced action to ensure there is sufficient free space on the runner. Let's let CI run through a few times to verify it works.