### PR TITLE
fix: readme action status badge incorrectly shows failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/rvolosatovs/docker-protobuf/workflows/Docker%20Image/badge.svg)
+![](https://github.com/rvolosatovs/docker-protobuf/actions/workflows/dockerimage.yml/badge.svg)
 
 # Protocol Buffers + Docker
 An all-inclusive `protoc` Docker image.


### PR DESCRIPTION
Fix the badge incorrectly showing failed status, this syntax must have changed.