### PR TITLE
fix: renovate not matching updated node versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,7 +83,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["^deps\\.list$"],
-      "matchStrings": ["NODE_IMAGE_VERSION=(?<currentValue>.*?)-alpine3.17\\n"],
+      "matchStrings": ["NODE_IMAGE_VERSION=(?<currentValue>.*?)-alpine\\d+\\.\\d+\\n"],
       "depNameTemplate": "node",
       "datasourceTemplate": "node",
       "versioningTemplate": "node"


### PR DESCRIPTION
This should get renovate updates to the node image working automatically again. Node is already almost up to date from manually bumping the version, this fix is for renovate only.