### PR TITLE
fix: Could not make proto path relative

### DIFF
--- a/protoc-wrapper
+++ b/protoc-wrapper
@@ -3,7 +3,7 @@ includes=()
 outs=()
 args=()
 
-for arg in "$@"; do
+for arg in $@; do
     case $arg in
         -I*|--proto_path=*)
             includes+=("$arg")


### PR DESCRIPTION
Resolves https://github.com/rvolosatovs/docker-protobuf/issues/507

The quoting change stopped glob expansion, which is needed when users pass globs in arguments