### PR TITLE
ci: fix invalid renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "onboarding": false,
   "platform": "github",
-  "includeForks": true,
+  "forkProcessing": "enabled",
   "repositories": ["rvolosatovs/docker-protobuf"],
   "enabledManagers": ["custom.regex"],
   "customManagers": [


### PR DESCRIPTION
Renovate seems to have stopped working due to a change in config schema. This should fix it, but I'm not sure if you need to change something in GitHub repo settings to re-enable it @rvolosatovs 