### PR TITLE
ci: clean-up

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,16 +17,23 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        build-mount-path: /home/runner/work/_temp/docker
-        root-reserve-mb: 10240
-        remove-dotnet: true
-        remove-android: true
-        remove-haskell: true
-        remove-codeql: true
-        remove-docker-images: true
+    - name: Remove unused files
+      # based on https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
+      run: |
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/julia*
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/share/chromium
+        sudo rm -rf /opt/microsoft /opt/google
+        sudo rm -rf /opt/az
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /opt/hostedtoolcache
+        docker system prune -af || true
+        docker builder prune -af || true
+        df -h
 
     - name: Move Docker data root to work directory
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -51,8 +51,6 @@ jobs:
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v3
-      with:
-        image: tonistiigi/binfmt:master
 
     - name: Docker meta
       id: docker_meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ ARG PROTOC_GEN_TS_VERSION=0.15.0
 ARG PROTOC_GEN_VALIDATE_VERSION=v1.2.1
 ARG RUST_IMAGE_VERSION=1.88.0-alpine3.22
 ARG SCALA_SBT_IMAGE_VERSION=graalvm-ce-22.3.3-b1-java17_1.9.9_2.12.18
-ARG SWIFT_IMAGE_VERSION=6.1.2
+ARG SWIFT_IMAGE_VERSION=6.1.2-noble
 ARG SWIFT_SDK_CHECKSUM=df0b40b9b582598e7e3d70c82ab503fd6fbfdff71fd17e7f1ab37115a0665b3b
 ARG UPX_VERSION=5.0.2
 ARG XX_IMAGE_VERSION=1.6.1
@@ -324,12 +324,12 @@ RUN install -D /grpc-rust/target/$(xx-cargo --print-target-triple)/release/proto
 RUN xx-verify /out/usr/bin/protoc-gen-rust-grpc
 
 
-FROM --platform=$BUILDPLATFORM swift:${SWIFT_IMAGE_VERSION}-noble AS swift_target
-ARG SWIFT_IMAGE_VERSION
-ARG SWIFT_SDK_CHECKSUM
+FROM --platform=$BUILDPLATFORM swift:${SWIFT_IMAGE_VERSION} AS swift_target
 RUN apt-get update && \
     apt-get install -y curl
-RUN export SWIFT_SDK_VERSION=$(echo ${SWIFT_IMAGE_VERSION} | sed -E 's/([0-9]+\.[0-9]+)\.0/\1/') && \
+ARG SWIFT_IMAGE_VERSION
+ARG SWIFT_SDK_CHECKSUM
+RUN export SWIFT_SDK_VERSION=$(echo ${SWIFT_IMAGE_VERSION} | cut -d'-' -f1) && \
     swift sdk install \
     https://download.swift.org/swift-$SWIFT_SDK_VERSION-release/static-sdk/swift-$SWIFT_SDK_VERSION-RELEASE/swift-$SWIFT_SDK_VERSION-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
     --checksum ${SWIFT_SDK_CHECKSUM}

--- a/Dockerfile
+++ b/Dockerfile
@@ -351,9 +351,8 @@ RUN <<EOF
 EOF
 
 FROM --platform=$BUILDPLATFORM swift_target AS protoc_gen_grpc_swift
-ARG PROTOC_GEN_GRPC_SWIFT_VERSION
 RUN mkdir -p /grpc-swift-protobuf
-RUN echo ${PROTOC_GEN_GRPC_SWIFT_VERSION}
+ARG PROTOC_GEN_GRPC_SWIFT_VERSION
 RUN curl -sSL https://api.github.com/repos/grpc/grpc-swift-protobuf/tarball/${PROTOC_GEN_GRPC_SWIFT_VERSION} | tar xz --strip 1 -C /grpc-swift-protobuf
 WORKDIR /grpc-swift-protobuf
 ARG TARGETOS TARGETARCH
@@ -368,9 +367,8 @@ RUN <<EOF
 EOF
 
 FROM --platform=$BUILDPLATFORM swift_target AS protoc_gen_grpc_swift_2
-ARG PROTOC_GEN_GRPC_SWIFT_2_VERSION
 RUN mkdir -p /grpc-swift-protobuf
-RUN echo ${PROTOC_GEN_GRPC_SWIFT_2_VERSION}
+ARG PROTOC_GEN_GRPC_SWIFT_2_VERSION
 RUN curl -sSL https://api.github.com/repos/grpc/grpc-swift-protobuf/tarball/${PROTOC_GEN_GRPC_SWIFT_2_VERSION} | tar xz --strip 1 -C /grpc-swift-protobuf
 WORKDIR /grpc-swift-protobuf
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
- the disk clean-up job takes way too long (I've seen it run for 5 minutes), let's see if we can just `rm -rf` with better results (based on https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg#6-how-to-automate-cleanup-in-your-ci)
- looks like we should not need `master` image of `binfmt` anymore