### PR TITLE
ci: speed-up cleanup

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -31,9 +31,6 @@ jobs:
         sudo rm -rf /opt/az
         sudo rm -rf /usr/local/share/powershell
         sudo rm -rf /opt/hostedtoolcache
-        docker system prune -af || true
-        docker builder prune -af || true
-        df -h
 
     - name: Move Docker data root to work directory
       run: |


### PR DESCRIPTION
Docker clean-up steps consistently do not clean up anything and e.g. this run took 7 minutes 🤯 https://github.com/rvolosatovs/docker-protobuf/actions/runs/19236400786/job/54987407367?pr=540

Let's only do stuff we really care about