### PR TITLE
chore: remove `grpc-rust`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ARG PROTOC_GEN_NANOPB_VERSION=0.4.9.1
 # renovate: datasource=github-releases depName=protoc-gen-openapi packageName=solo-io/protoc-gen-openapi
 ARG PROTOC_GEN_OPENAPI_VERSION=v0.3.1
 ARG PROTOC_GEN_PBANDK_VERSION=0.16.0
-# renovate: datasource=github-tags depName=grpc-rust packageName=stepancheg/rust-protobuf
+# renovate: datasource=github-tags depName=rust-protobuf packageName=stepancheg/rust-protobuf
 ARG PROTOC_GEN_RUST_VERSION=v3.7.2
 # renovate: datasource=github-releases depName=protoc-gen-scala packageName=scalapb/ScalaPB
 ARG PROTOC_GEN_SCALA_VERSION=v0.11.17

--- a/protoc-test
+++ b/protoc-test
@@ -61,7 +61,6 @@ PLUGINS=(
   [grpc-php_out]="--grpc-php_out=$OUTDIR Test/TestServiceClient.php"
   [grpc-python_out]="--grpc-python_out=$OUTDIR test_message_pb2_grpc.py"
   [grpc-ruby_out]="--grpc-ruby_out=$OUTDIR test_message_services_pb.rb"
-  [grpc-rust_out]="--grpc-rust_out=$OUTDIR test_message_grpc.rs"
   [grpc-swift_out]="--grpc-swift_out=$OUTDIR test_message.grpc.swift"
   [grpc-web_out]="--grpc-web_out=import_style=commonjs,mode=grpcwebtext:$OUTDIR test_message_grpc_web_pb.js"
   [java_out]="--java_out=$OUTDIR test/TestMessageOuterClass.java"


### PR DESCRIPTION
It's been deprecated for 1.5 year https://github.com/stepancheg/grpc-rust/commit/c54120fc786b7c8d66e7f93a41d93b66d4480eae