### PR TITLE
chore: remove stale `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-set -a
-
-. ./deps.list
-docker buildx build \
-    $(for v in $(cut -d '=' -f 1 < deps.list); do printf "%s " "--build-arg $v=$(printenv ${v})"; done) \
-    ${@} .


### PR DESCRIPTION
Just noticed we have a stale `build.sh` laying around, which seems unnecessary, since we can just `docker build .` now