### PR TITLE
ci: auto-merge docker and Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,8 @@
     "config:best-practices",
     ":semanticPrefixChore",
     ":automergeAll",
-    ":gomod",
   ],
+  "enabledManagers": ["dockerfile", "custom.regex"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,19 @@
+name: dependabot
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - id: meta
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+    - if: steps.meta.outputs.package-ecosystem == 'go_modules'
+      run: gh pr merge --auto --rebase "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switch to dependabot for Go updates and automerge everything that's not GitHub Action update (since this could compromise our CI pipeline)